### PR TITLE
Fix server debugging: replace unsupported --debug flag with --inspect

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,37 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-    "version": "0.1.0",
-    "configurations": [
-        {
-            "name": "Launch Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src",
-            "preLaunchTask": "npm"
-        },
-        {
-            "name": "Launch Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/test",
-            "preLaunchTask": "npm"
-        }
-    ]
+  "version": "0.1.0",
+  "configurations": [
+    {
+      "name": "Launch Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/client/out/src/**/*.js"
+      ],
+      "preLaunchTask": "npm"
+    },
+    {
+      "name": "Launch Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}",
+        "--extensionTestsPath=${workspaceRoot}/out/test"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/out/test/**/*.js"
+      ],
+      "preLaunchTask": "npm"
+    }
+  ]
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -32,8 +32,8 @@ export async function launch(context: vscode.ExtensionContext): Promise<void> {
   const reasonConfig = vscode.workspace.getConfiguration("reason");
   const module = context.asAbsolutePath(path.join("node_modules", "ocaml-language-server"));
   const transport = client.TransportKind.ipc;
-  const run = { module, transport, args: ["--node-ipc"], options: {} };
-  const debug = { module, transport, args: ["--node-ipc"], options: { execArgv: [ "--nolazy", "--debug=6004" ] } };
+  const run = { module, transport };
+  const debug = { module, transport, options: { execArgv: [ "--nolazy", "--inspect=6004" ] } };
   const serverOptions = { run, debug };
   const clientOptions: client.LanguageClientOptions = {
     diagnosticCollectionName: "Reason",


### PR DESCRIPTION
Required to debug `ocaml-language-server` downstream.

Updated the client to use `--inspect` instead of `--debug`. The latter [seems to be deprecated](https://github.com/Microsoft/vscode/issues/33951#issuecomment-327879453). Removed `--node-ipc` as it's being passed already in `transport`.

Formatted `launch.json` and replaced `outDir` (deprecated) with `outFiles` (better review with `w=1` to avoid white spaces).

_Note: until https://github.com/Microsoft/vscode/issues/33951 is solved, in order to make the server debugger work correctly, `options: { execArgv: [ "--nolazy", "--debug=6004" ] }` has to also be set [in `run`](https://github.com/reasonml-editor/vscode-reasonml/blob/8c029c5bba921e75d30f2373f1175961eb48fbce/src/client/index.ts#L35)_