### PR TITLE
Replace bsb.enabled with diagnostics.tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,8 +196,7 @@
         ],
         "extensions": [
           ".ml",
-          ".mli",
-          ".mly"
+          ".mli"
         ],
         "configuration": "./ocaml.configuration.json"
       },

--- a/package.json
+++ b/package.json
@@ -67,11 +67,12 @@
             ]
           },
           "default": [
-            "merlin"
+            "merlin",
+            "bsb"
           ],
           "maxItems": 2,
           "uniqueItems": true,
-          "description": "Specifies which tool or tools will be used to get diagnostics."
+          "description": "Specifies which tool or tools will be used to get diagnostics. If you choose both \"merlin\" and \"bsb\", merlin will be used while editing and bsb when saving."
         },
         "reason.formatOnSave": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,6 @@
       "type": "object",
       "title": "Reason configuration",
       "properties": {
-        "reason.bsb.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Specifies whether `bsb` is used to get diagnostics."
-        },
         "reason.codelens.unicode": {
           "type": "boolean",
           "default": true,
@@ -62,6 +57,21 @@
           "type": "integer",
           "default": 500,
           "description": "How long to idle (in milliseconds) after keypresses before refreshing linter diagnostics. Smaller values refresh diagnostics more quickly."
+        },
+        "reason.diagnostics.tools": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "merlin",
+              "bsb"
+            ]
+          },
+          "default": [
+            "merlin"
+          ],
+          "maxItems": 2,
+          "uniqueItems": true,
+          "description": "Specifies which tool or tools will be used to get diagnostics."
         },
         "reason.formatOnSave": {
           "type": "boolean",
@@ -186,7 +196,8 @@
         ],
         "extensions": [
           ".ml",
-          ".mli"
+          ".mli",
+          ".mly"
         ],
         "configuration": "./ocaml.configuration.json"
       },

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -5,15 +5,15 @@ import * as types from "./types";
 
 export interface ISettings {
   reason: {
-    bsb: {
-      enabled: boolean;
-    };
     codelens: {
       enabled: boolean;
       unicode: boolean;
     };
     debounce: {
       linter: number;
+    };
+    diagnostics: {
+      tools: Array<"merlin" | "bsb">,
     };
     path: {
       bsb: string;
@@ -33,15 +33,15 @@ export interface ISettings {
 export namespace ISettings {
   export const defaults: ISettings = {
     reason: {
-      bsb: {
-        enabled: false,
-      },
       codelens: {
         enabled: true,
         unicode: true,
       },
       debounce: {
         linter: 500,
+      },
+      diagnostics: {
+        tools: ["merlin"],
       },
       path: {
         bsb: "bsb",


### PR DESCRIPTION
Companion PR of https://github.com/freebroccolo/ocaml-language-server/pull/42.

There was some feedback on Discord about users wanting more control over which tool would be used for diagnostic. This PR changes `bsb.enabled` (boolean) with `diagnostics.tools`(array) so users can decide if they want `merlin`, `bsb` or both, or none :)

@freebroccolo @chenglou What do you think? cc @superherointj 