### PR TITLE
Make bsb opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
             ]
           },
           "default": [
-            "merlin",
-            "bsb"
+            "merlin"
           ],
           "maxItems": 2,
           "uniqueItems": true,


### PR DESCRIPTION
I was talking to @chenglou on Discord. Considering OCaml users that are using v4.03+ and also Reason native users, I think it's safer to enable bsb optionally, instead of considering the default.

@freebroccolo @chenglou What are your thoughts?