### PR TITLE
Renames aliases as all langs had the same OCaml alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
       {
         "id": "ocaml.merlin",
         "aliases": [
-          "OCaml"
+          "Merlin"
         ],
         "extensions": [
           "merlin"
@@ -218,7 +218,7 @@
       {
         "id": "ocaml.ocamlbuild",
         "aliases": [
-          "OCaml"
+          "OCamlbuild"
         ],
         "extensions": [
           "_tags"
@@ -227,7 +227,7 @@
       {
         "id": "ocaml.opam",
         "aliases": [
-          "OCaml"
+          "OPAM"
         ],
         "extensions": [
           "opam"


### PR DESCRIPTION
Because of this, selecting `OCaml` for syntax highlighting in the was not possible because ocaml.merlin, ocaml.ocamlbuild and ocaml.opam were shadowing OCaml because of their alias:
![capture d ecran 2017-10-23 a 11 32 07](https://user-images.githubusercontent.com/2195781/31882122-12244d54-b7e6-11e7-9460-fa77c985dc28.png)

With this fix, it is now possible to select the ocaml syntax highlighting:
![capture d ecran 2017-10-23 a 11 32 30](https://user-images.githubusercontent.com/2195781/31882121-109d5282-b7e6-11e7-889d-c102931ac116.png)
