### PR TITLE
Consume Two New APIs in `ocaml-language-server`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
       {
         "command": "reason.showMerlinFiles",
         "title": "Reason: show merlin files"
+      },
+      {
+        "command": "reason.showAvailableLibraries",
+        "title": "Reason: show ocamlfind libraries provided by dependencies"
+      },
+      {
+        "command": "reason.showProjectEnv",
+        "title": "Reason: show project environment."
       }
     ],
     "configuration": {
@@ -76,6 +84,16 @@
           "type": "string",
           "default": "ocamlfind",
           "description": "The path to the `ocamlfind` binary."
+        },
+        "reason.path.esy": {
+          "type": "string",
+          "default": "esy",
+          "description": "The path to the `esy` binary."
+        },
+        "reason.path.env": {
+          "type": "string",
+          "default": "env",
+          "description": "The path to the `env` command which prints the language server environment for debugging editor issues."
         },
         "reason.path.ocamlmerlin": {
           "type": "string",

--- a/src/client/command/doShowAvailableLibraries.ts
+++ b/src/client/command/doShowAvailableLibraries.ts
@@ -1,0 +1,25 @@
+import { remote, types } from "ocaml-language-server";
+import * as vscode from "vscode";
+import * as client from "vscode-languageclient";
+
+export function register(
+  context: vscode.ExtensionContext,
+  languageClient: client.LanguageClient,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      "reason.showAvailableLibraries",
+      async editor => {
+        const docURI: types.TextDocumentIdentifier = {
+          uri: editor.document.uri.toString(),
+        };
+        const libraryLines = languageClient.sendRequest(
+          remote.server.giveAvailableLibraries,
+          docURI,
+        );
+        await vscode.window.showQuickPick(libraryLines);
+        return;
+      },
+    ),
+  );
+}

--- a/src/client/command/doShowProjectEnv.ts
+++ b/src/client/command/doShowProjectEnv.ts
@@ -1,0 +1,34 @@
+import { remote, types } from "ocaml-language-server";
+import * as vscode from "vscode";
+import * as client from "vscode-languageclient";
+
+const SHOW_ALL_STR = "Show Entire Environment";
+export function register(
+  context: vscode.ExtensionContext,
+  languageClient: client.LanguageClient,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      "reason.showProjectEnv",
+      async editor => {
+        const docURI: types.TextDocumentIdentifier = {
+          uri: editor.document.uri.toString(),
+        };
+        const projectEnv: string[] = await languageClient.sendRequest(
+          remote.server.giveProjectEnv,
+          docURI,
+        );
+        const projectEnvWithAll = [SHOW_ALL_STR].concat(projectEnv);
+        const selected = await vscode.window.showQuickPick(projectEnvWithAll);
+        if (selected === undefined || selected === null) return;
+        const content =
+          selected === SHOW_ALL_STR ? projectEnv.join("\n") : selected;
+        const textDocument = await vscode.workspace.openTextDocument({
+          content,
+          language: "shellscript",
+        });
+        await vscode.window.showTextDocument(textDocument);
+      },
+    ),
+  );
+}

--- a/src/client/command/index.ts
+++ b/src/client/command/index.ts
@@ -1,7 +1,9 @@
 import * as vscode from "vscode";
 import * as client from "vscode-languageclient";
 import * as doClearDiagnostics from "./doClearDiagnostics";
+import * as doShowAvailableLibraries from "./doShowAvailableLibraries";
 import * as doShowMerlinFiles from "./doShowMerlinFiles";
+import * as doShowProjectEnv from "./doShowProjectEnv";
 import * as doSplitCases from "./doSplitCases";
 import * as fixEqualsShouldBeArrow from "./fixEqualsShouldBeArrow";
 import * as fixMissingSemicolon from "./fixMissingSemicolon";
@@ -13,6 +15,8 @@ export function registerAll(
 ): void {
   doClearDiagnostics.register(context, languageClient);
   doShowMerlinFiles.register(context, languageClient);
+  doShowProjectEnv.register(context, languageClient);
+  doShowAvailableLibraries.register(context, languageClient);
   doSplitCases.register(context, languageClient);
   fixEqualsShouldBeArrow.register(context, languageClient);
   fixMissingSemicolon.register(context, languageClient);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -61,6 +61,8 @@ export async function launch(context: vscode.ExtensionContext): Promise<void> {
         vscode.workspace.createFileSystemWatcher("**/.merlin"),
         vscode.workspace.createFileSystemWatcher("**/*.ml"),
         vscode.workspace.createFileSystemWatcher("**/*.re"),
+        vscode.workspace.createFileSystemWatcher("**/command-exec"),
+        vscode.workspace.createFileSystemWatcher("**/command-exec.bat"),
       ],
     },
   };


### PR DESCRIPTION
New UI for the [corresponding server introspection API PR](https://github.com/freebroccolo/ocaml-language-server/pull/68):

Do not merge this unless that PR is also merged.

This provides the UI for those two new server introspection APIs. Read
the sumary in that other PR.