### PR TITLE
fix incorrect pipe insertion after quoted string

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ const reasonConfiguration = {
       },
     },
     {
-      beforeText: /^(\t|[ ]{2})*[\|]([^!$%&*+-/<=>?@^~;])*(?:$|=>.*[^\s\{]\s*$)/m,
+      beforeText: /^(\t|[ ]{2})*[\|]([^!$%&*+-/<=>?@^~;}])*(?:$|=>.*[^\s\{]\s*$)/m,
       action: {
         indentAction: vscode.IndentAction.None,
         appendText: "| ",


### PR DESCRIPTION
Fixes incorrect pipe insertion after quoted string, e.g.

(`$` indicating caret)

```ml
let x = {|
|}$
```

```ml
let x = {blah|
|blah}$
```