### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,6 +291,7 @@
     "vscode:prepublish": "node script/syntax.js"
   },
   "devDependencies": {
+    "@types/lodash.flatmap": "^4.5.3",
     "@types/node": "9.6.2",
     "@types/pegjs": "0.10.0",
     "prettier": "1.11.1",
@@ -299,6 +300,7 @@
     "vscode": "1.1.14"
   },
   "dependencies": {
+    "lodash.flatmap": "^4.5.0",
     "ocaml-language-server": "1.0.34",
     "pegjs": "0.10.0",
     "vscode-jsonrpc": "3.6.0",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,4 @@
+import flatMap = require("lodash.flatmap");
 import * as path from "path";
 import * as vscode from "vscode";
 import * as client from "vscode-languageclient";
@@ -39,9 +40,15 @@ export async function launch(context: vscode.ExtensionContext): Promise<void> {
     transport,
   };
   const serverOptions = { run, debug };
+  const languages = reasonConfig.get<string[]>("server.languages", ["ocaml", "reason"]);
+  const documentSelector = flatMap(languages, (language: string) => [
+    { language, scheme: "file" },
+    { language, scheme: "untitled" },
+  ]);
+
   const clientOptions: client.LanguageClientOptions = {
     diagnosticCollectionName: "ocaml-language-server",
-    documentSelector: reasonConfig.get<string[]>("server.languages", ["ocaml", "reason"]),
+    documentSelector,
     errorHandler: new ErrorHandler(),
     initializationOptions: reasonConfig,
     outputChannelName: "OCaml Language Server",


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](http://aka.ms/vsls) adding support for "guests" to receive remote language services for Reason/OCaml, this PR updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Reason/OCaml project using Live Share, and doesn't have the Reason extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Reason extension installed. Additionally, this wouldn't impact the "local" Reason development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*