### PR TITLE
[vscode] Use local path for bsb and refmt

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         },
         "reason.path.bsb": {
           "type": "string",
-          "default": "bsb",
+          "default": "./node_modules/bs-platform/lib/bsb.exe",
           "description": "The path to the `bsb` binary."
         },
         "reason.path.ocamlfind": {
@@ -121,7 +121,7 @@
         },
         "reason.path.refmt": {
           "type": "string",
-          "default": "refmt",
+          "default": "./node_modules/bs-platform/lib/bsrefmt",
           "description": "The path to the `refmt` binary."
         },
         "reason.path.refmterr": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
         },
         "reason.path.refmt": {
           "type": "string",
-          "default": "./node_modules/bs-platform/lib/bsrefmt",
+          "default": "refmt",
           "description": "The path to the `refmt` binary."
         },
         "reason.path.refmterr": {


### PR DESCRIPTION
Fixes #203.

Companion of https://github.com/freebroccolo/ocaml-language-server/pull/120.

Tested on macOS.

This PR changes a couple of things:
- `reason.path.bsb` uses the exe format that is around 1 order of magnitude faster for small projects (cc @bobzhang)
- `reason.path.refmt` and `reason.path.bsb` point to the `bs-platform` local binaries so any incompatible updates don't break existing projects (plus, both tools are kept in sync).

The users of WSL in Windows shouldn't be affected as they already have to override this flag to make WSL work.

The main downside is that it breaks a potential usage in native Windows, but I believe there are other more critical things to solve on that front first, so we can revisit when it's ready.