### PR TITLE
[vscode][#214] syntax highlight for markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,26 @@
         "language": "reason.hover.type",
         "scopeName": "source.reason.hover.type",
         "path": "./syntaxes/reason-hover-type.json"
+      },
+      {
+        "scopeName": "markdown.reason.codeblock",
+        "path": "./syntaxes/reason-markdown-codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.reason": "reason"
+        }
+      },
+      {
+        "scopeName": "markdown.ocaml.codeblock",
+        "path": "./syntaxes/ocaml-markdown-codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.ocaml": "ocaml"
+        }
       }
     ],
     "languages": [

--- a/syntaxes/ocaml-markdown-codeblock.json
+++ b/syntaxes/ocaml-markdown-codeblock.json
@@ -1,0 +1,26 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:markup.fenced_code.block.markdown",
+	"patterns": [
+    { "include": "#ocaml-code-block" }
+	],
+	"repository": {
+		"ocaml-code-block": {
+			"begin": "(ml|ocaml)(\\s+[^`~]*)?$",
+			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.ocaml",
+					"patterns": [
+						{
+							"include": "source.ocaml"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.ocaml.codeblock"
+}

--- a/syntaxes/reason-markdown-codeblock.json
+++ b/syntaxes/reason-markdown-codeblock.json
@@ -1,0 +1,26 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:markup.fenced_code.block.markdown",
+	"patterns": [
+    { "include": "#reason-code-block" }
+	],
+	"repository": {
+		"reason-code-block": {
+			"begin": "(re|reason|reasonml)(\\s+[^`~]*)?$",
+			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.reason",
+					"patterns": [
+						{
+							"include": "source.reason"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.reason.codeblock"
+}


### PR DESCRIPTION
try to resolve issue #214 
Noted that this only improve for markdown editing side, I guess the preview side use its own highlighting which we might need PR to

I do have issues with writing regex :( 
* `re`-prefixed codeblock doesn't work, I have no idea why
* no idea how to do ignore-case in pattern there, i tried `(?i)` and `//i` but none works.

