### PR TITLE
Adds command for switching from Implementation to Signature and vice versa

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       {
         "command": "reason.showProjectEnv",
         "title": "Reason: Show Environment"
+      },
+      {
+        "command": "reason.switchSigImpl",
+        "title": "Reason: Switch Signature/Implementation"
       }
     ],
     "configuration": {
@@ -281,7 +285,6 @@
     "problemMatchers": [
       {
         "name": "ocamlc",
-
         "fileLocation": ["relative", "${workspaceFolder}"],
         "pattern": [
           {

--- a/src/client/command/index.ts
+++ b/src/client/command/index.ts
@@ -7,6 +7,7 @@ import * as doSplitCases from "./doSplitCases";
 import * as fixEqualsShouldBeArrow from "./fixEqualsShouldBeArrow";
 import * as fixMissingSemicolon from "./fixMissingSemicolon";
 import * as fixUnusedVariable from "./fixUnusedVariable";
+import * as switchSigImpl from "./switchSigImpl";
 
 export function registerAll(context: vscode.ExtensionContext, languageClient: client.LanguageClient): void {
   doShowMerlinFiles.register(context, languageClient);
@@ -16,4 +17,5 @@ export function registerAll(context: vscode.ExtensionContext, languageClient: cl
   fixEqualsShouldBeArrow.register(context, languageClient);
   fixMissingSemicolon.register(context, languageClient);
   fixUnusedVariable.register(context, languageClient);
+  switchSigImpl.register(context);
 }

--- a/src/client/command/switchSigImpl.ts
+++ b/src/client/command/switchSigImpl.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as Path from "path";
+import * as vscode from "vscode";
+
+const fsWriteFile = (path: string, data: string) =>
+  new Promise(resolve => {
+    fs.writeFile(path, data, resolve);
+  });
+
+interface IExtToStringObj {
+  [key: string]: string;
+}
+
+export function register(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand("reason.switchSigImpl", async () => {
+      const editor = vscode.window.activeTextEditor;
+      const doc = editor != null ? editor.document : null;
+      const path = doc != null ? doc.fileName : "";
+      const ext = Path.extname(path || "");
+      const extMatcher: IExtToStringObj = { ".mli": ".ml", ".ml": ".mli", ".re": ".rei", ".rei": ".re" };
+      const newExt: string = extMatcher[ext];
+      if (!newExt) {
+        vscode.window.showInformationMessage("Target file must be a Reason or OCaml signature or implementation file");
+        return;
+      }
+      const newPath = path.substring(0, path.length - ext.length) + newExt;
+      fs.access(newPath, async err => {
+        if (err) {
+          const nameMatcher: IExtToStringObj = {
+            ".ml": "Implementation",
+            ".mli": "Signature",
+            ".re": "Implementation",
+            ".rei": "Signature",
+          };
+          const name = nameMatcher[newExt];
+          const result = await vscode.window.showInformationMessage(`${name} file doesn't exist.`, "Create It");
+          if (result === "Create It") {
+            await fsWriteFile(newPath, "");
+          } else {
+            return;
+          }
+        }
+        await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(newPath));
+      });
+    }),
+  );
+}


### PR DESCRIPTION
Hey :) This PR adds a simple command that allows a user to switch between the implementation file (.ml/.re) and the interface file (.mli/.rei).

I basically took this from the deprecated ocaml vs-code package because I found it quite useful.