### PR TITLE
Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Although syntax highlighting should display well in most themes we recommend and
 ### Configurations
 #### Reason
 
-- [Reason](https://reasonml.github.io/docs/en/global-installation.html#recommended-through-npm-yarn)
+- [Reason](https://reasonml.github.io/docs/en/installation)
 
 The Reason installation steps also installs Merlin for you, so you can skip the Merlin installation in the next section.
 


### PR DESCRIPTION
Broken link to installation instructions for Reason: `https://reasonml.github.io/docs/en/global-installation.html` is a 404; I replaced with `https://reasonml.github.io/docs/en/installation` (best guess).