### PR TITLE
fix(syntaxes/reason-md): fewer false positives

### DIFF
--- a/syntaxes/reason-markdown-codeblock.json
+++ b/syntaxes/reason-markdown-codeblock.json
@@ -6,7 +6,7 @@
 	],
 	"repository": {
 		"reason-code-block": {
-			"begin": "(re|reason|reasonml)(\\s+[^`~]*)?$",
+			"begin": "\\b(re|reason|reasonml)\\b(\\s+[^`~]*)?$",
 			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
 			"patterns": [
 				{


### PR DESCRIPTION
Addresses, but does not fully close, issue #250.

VSCode uses Java-syntax regex instead of JS for some reason? Also, you need to escape `\` characters because this is a JSON file. Finally, I am not sure what the `begin` is actually relevant to. However, the upshot is that using word boundary (`\b`) cuts down on the number of false positive hits on the ReasonML markdown code block syntax highlighting due to "re" etc. appearing _anywhere_ in the code fence.

Maddeningly, I couldn't figure out what secret sauce would actually match on the starting triple-backtick, so stuff like this still triggers the syntax highlighting:

```
some re stuff
f >=> g
```

At some point I or someone else will have to figure out a proper regex for this. But for now this PR helps in many cases.