### PR TITLE
Update README: install ocp-indent / refmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To enable formatting on save, add the following to `Code > Preferences > Setting
 }
 ```
 
+For formatting, make sure you have `ocp-indent` (for OCaml) and `refmt` (for ReasonML), installed and available in your `PATH`, otherwise this extension will currently crash ([issue](#142)).
+
 If you want to enable [codelens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup), add the following to `Code > Preferences > Settings`:
 ```
 "reason.codelens.enabled": true


### PR DESCRIPTION
I was recently bitten by this: I had `editor.formatOnSave` enabled, but I didn't know I needed to install `ocp-indent`. The extension crashes, and it's quite difficult to troubleshoot.

Before #269 gets merged and released, can we update the README, to help others who might hit this.

related #142 
fixes #247