### PR TITLE
Fixes unexpected behavior of (**

### DIFF
--- a/ocaml.configuration.json
+++ b/ocaml.configuration.json
@@ -4,7 +4,7 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": [ "string" ] },
-    { "open": "(**", "close": " *)", "notIn": [ "string" ] }
+    { "open": "(**", "close": " *", "notIn": [ "string" ] }
   ],
   "brackets": [
     [ "{", "}" ],


### PR DESCRIPTION
Related to # 254.

Because of the rule `{ "open": "(", "close": ")" }`, the extra parentheses will be appended to the end if we type `(**`, remove ")" in `"close": "*)"` can solve this problem.